### PR TITLE
About the grant access dialog

### DIFF
--- a/app/src/main/java/dev/dworks/apps/anexplorer/misc/SAFManager.java
+++ b/app/src/main/java/dev/dworks/apps/anexplorer/misc/SAFManager.java
@@ -103,8 +103,9 @@ public class SAFManager {
     @TargetApi(Build.VERSION_CODES.KITKAT)
     private Uri getRootUri(String docId){
         Uri treeUri;
-        final int splitIndex = docId.indexOf(':', 1);
-        final String tag = docId.substring(0, splitIndex);
+//        final int splitIndex = docId.indexOf(':', 1);
+//        final String tag = docId.substring(0, splitIndex);
+        final String tag = docId;
 
         //check in cache
         treeUri = secondaryRoots.get(tag);


### PR DESCRIPTION
When user grant access permissions to the sub-folder of the sdcard, The grant access dialog will repeat show before next session, even if grant this permissions to other folder. I think the reason for this issues is the tag use a wrong value.