### PR TITLE
Fixed apk naming issue after Gradle 3.1.0 update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,12 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 27
     buildToolsVersion '27.0.0'
+    
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "${parent.name}-${variant.name}-${variant.versionName}.apk"
+        }
+    }
 
     defaultConfig {
         versionName "3.7"


### PR DESCRIPTION
So after I upgraded my Android Studio to the stable 3.0 update and started using Gradle 3.1.0-alpha3, I noticed my Android Studio could no longer build my apk and gives an error 

> `"Cannot set the value of read-only 'outputFile' for ApkVariantOutputImpl_Decorated{apkData=Main{type=MAIN......."`

So with this, I have successfully made a workaround to fix this issue. This fix gives a fine filename like "AnExplorer-debug-1.0.0.apk" for debug and "AnExplorer-release-1.0.0.apk" for release.
@1hakr ..Please check this out and merge this pull request