### PR TITLE
Fix unnecessary length check

### DIFF
--- a/app/src/main/java/dev/dworks/apps/anexplorer/misc/Utils.java
+++ b/app/src/main/java/dev/dworks/apps/anexplorer/misc/Utils.java
@@ -239,10 +239,12 @@ public class Utils extends UtilsFlavour{
 		return DateUtils.formatDateTime(context, when, flags);
 	}
 
+	// todo ここなおす
     public static long getDirectorySize(File dir) {
 		long result = 0L;
-		if (dir.listFiles() != null && dir.listFiles().length > 0) {
-			for (File eachFile : dir.listFiles()) {
+		File[] files = dir.listFiles();
+		if (files != null) {
+			for (File eachFile : files) {
 				result += eachFile.isDirectory() && eachFile.canRead() ? getDirectorySize(eachFile) : eachFile.length();
 			}
 		} else if (!dir.isDirectory()) {

--- a/app/src/main/java/dev/dworks/apps/anexplorer/misc/Utils.java
+++ b/app/src/main/java/dev/dworks/apps/anexplorer/misc/Utils.java
@@ -239,7 +239,6 @@ public class Utils extends UtilsFlavour{
 		return DateUtils.formatDateTime(context, when, flags);
 	}
 
-	// todo ここなおす
     public static long getDirectorySize(File dir) {
 		long result = 0L;
 		File[] files = dir.listFiles();


### PR DESCRIPTION
I fixed it that delete checking for length.
Because, not run `for each` when `length == 0`